### PR TITLE
AI A2A Refueling

### DIFF
--- a/AI/Refueling/Refuel.trk
+++ b/AI/Refueling/Refuel.trk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:101901aa60233fed5156a7d21714bd5bcbc1f5aa49aef8305546ddeb51428525
+size 145901


### PR DESCRIPTION
Added track for AI A2A refueling for several aircraft types:
- F-16C refueling at KC-135
- F/A-18C refueling at KC-130
- A-10C II refueling at KC-135 

All AI groups are four-ships, where each element has a different number of fuel tanks (from 0 to 3).
Test will only be successful if all 12 aircraft manage take fuel larger than a given threshold (depending on number of external tanks).